### PR TITLE
workflow: Fix installing `cmake` on `arm64-Darwin`

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -68,4 +68,4 @@ jobs:
           pyenv install 2.7.18 && pyenv global 2.7.18
           # Downgrade cmake from cmake 4 to cmake 3
           brew uninstall cmake
-          pip3 install "cmake>=3.31,<3.32" --break-system-packages
+          pip3 install \"cmake>=3.31,<3.32\" --break-system-packages

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -68,4 +68,4 @@ jobs:
           pyenv install 2.7.18 && pyenv global 2.7.18
           # Downgrade cmake from cmake 4 to cmake 3
           brew uninstall cmake
-          pip3 install cmake>=3.31,<3.32 --break-system-packages
+          pip3 install "cmake>=3.31,<3.32" --break-system-packages

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -68,4 +68,4 @@ jobs:
           pyenv install 2.7.18 && pyenv global 2.7.18
           # Downgrade cmake from cmake 4 to cmake 3
           brew uninstall cmake
-          pip3 install cmake==3.31 --break-system-packages
+          pip3 install cmake>=3.31,<3.32 --break-system-packages


### PR DESCRIPTION
In #20, a workflow fail indicated the following error:
```
Could not find a version that satisfies the requirement cmake==3.31 (from versions: [...], 3.30.9, 3.31.0.1, 3.31.1, 3.31.2, 3.31.4, 3.31.6, 3.31.10, 4.0.0, [...])
```
We probably want to install the latest version from `3.31`, so this PR adjusts the install condition accordingly.